### PR TITLE
Fixed support for Windows globs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function parseGlob(str) {
     }
 
     rs.dir = glob2base(new glob.Glob(str));
-    rs.glob = str.replace(rs.dir, '');
+    rs.glob = str.replace(rs.dir, '').split(path.sep).join('/');
 
     if (/^.\//.test(rs.glob) || /^.\\/.test(rs.glob)) {
         rs.glob = rs.glob.substr(2);


### PR DESCRIPTION
Windows globs broke after `sane` migrated from minimatch to micromatch v3 https://github.com/amasad/sane/pull/115